### PR TITLE
Fix FlashDevelop support

### DIFF
--- a/bat/SetupSDK.bat
+++ b/bat/SetupSDK.bat
@@ -1,7 +1,7 @@
 :user_configuration
 
 :: Path to Flex SDK
-set FLEX_SDK=C:\Users\Gedan\AppData\Local\FlashDevelop\Apps\flexairsdk\4.6.0+16.0.0
+set FLEX_SDK=%LOCALAPPDATA%\FlashDevelop\Apps\flexairsdk\4.6.0+18.0.0
 set AUTO_INSTALL_IOS=yes
 
 :: Path to Android SDK

--- a/classes/TITSSaveEdit/Data/TiTsCharacterData.as
+++ b/classes/TITSSaveEdit/Data/TiTsCharacterData.as
@@ -378,7 +378,7 @@ package classes.TITSSaveEdit.Data
 			{
 				newObj = {
 					classInstance: "classes.Characters::PlayerCharacter",
-					version: DataManager.LATEST_SAVE_VERSION;
+					version: DataManager.LATEST_SAVE_VERSION
 				};
 			}
 			else


### PR DESCRIPTION
I develop with Flash CS6 + FlashDevelop since I hate Creative Cloud.

# Changes

 * Use `%LOCALAPPDATA%` to locate user's Local AppData directory instead of a hardcoded directory. Works on Windows 7, at least.
 * Update to Flex SDK 5.6.0 + 18.0.0 (latest available for FD)
 * Fix a compile error possibly caused by upgrade.  Please yell if this is an intentional stumbling block.

# Caveats

 * Still requires users to manually specify location of their Adobe Flash libraries since FD is dumb.